### PR TITLE
Feature/add extension points

### DIFF
--- a/CommonMarkConverter.php
+++ b/CommonMarkConverter.php
@@ -1,23 +1,31 @@
 <?php
 namespace Bcremer\Sculpin\Bundle\CommonMarkBundle;
 
-use League\CommonMark\CommonMarkConverter as LeagueCommonMarkConverter;
+use League\CommonMark\DocParser;
+use League\CommonMark\HtmlRendererInterface;
 use Sculpin\Core\Converter\ConverterContextInterface;
 use Sculpin\Core\Converter\ConverterInterface;
 
 class CommonMarkConverter implements ConverterInterface
 {
     /**
-     * @var LeagueCommonMarkConverter
+     * @var DocParser
      */
-    protected $converter;
+    private $parser;
 
     /**
-     * @param LeagueCommonMarkConverter $converter Parser
+     * @var HtmlRendererInterface
      */
-    public function __construct(LeagueCommonMarkConverter $converter)
+    private $renderer;
+
+    /**
+     * @param DocParser             $parser
+     * @param HtmlRendererInterface $renderer
+     */
+    public function __construct(DocParser $parser, HtmlRendererInterface $renderer)
     {
-        $this->converter = $converter;
+        $this->parser = $parser;
+        $this->renderer = $renderer;
     }
 
     /**
@@ -25,6 +33,10 @@ class CommonMarkConverter implements ConverterInterface
      */
     public function convert(ConverterContextInterface $converterContext)
     {
-        $converterContext->setContent($this->converter->convertToHtml($converterContext->content()));
+        $documentAST = $this->parser->parse($converterContext->content());
+
+        $converterContext->setContent(
+            $this->renderer->renderBlock($documentAST)
+        );
     }
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ class SculpinKernel extends \Sculpin\Bundle\SculpinBundle\HttpKernel\AbstractKer
 }
 ```
 
+## Defined services
+This bundle defines the following services in the sculpin DI Container:
+
+* `sculpin_commonmark.environment`
+* `sculpin_commonmark.docparser` 
+* `sculpin_commonmark.htmlrenderer`
+* `sculpin_commonmark.converter`
+* `sculpin_commonmark.event.commonmark`
+
 ## License
 
 The MIT License (MIT). Please see [License File](LICENSE) for more information.

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,10 +4,21 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="sculpin_commonmark.parser" class="League\CommonMark\CommonMarkConverter" />
+        <service id="sculpin_commonmark.environment" class="League\CommonMark\Environment">
+            <factory class="League\CommonMark\Environment" method="createCommonMarkEnvironment" />
+        </service>
+
+        <service id="sculpin_commonmark.docparser" class="League\CommonMark\DocParser">
+            <argument type="service" id="sculpin_commonmark.environment" />
+        </service>
+
+        <service id="sculpin_commonmark.htmlrenderer" class="League\CommonMark\HtmlRenderer" >
+            <argument type="service" id="sculpin_commonmark.environment" />
+        </service>
 
         <service id="sculpin_commonmark.converter" class="Bcremer\Sculpin\Bundle\CommonMarkBundle\CommonMarkConverter">
-            <argument type="service" id="sculpin_commonmark.parser" />
+            <argument type="service" id="sculpin_commonmark.docparser" />
+            <argument type="service" id="sculpin_commonmark.htmlrenderer" />
             <tag name="sculpin.converter" alias="commonmark" />
         </service>
 


### PR DESCRIPTION
Provide access to the lower level components of `League\CommonMark` (Environment, Parser, Renderer).

So the [Advanced Usage & Customization](https://github.com/thephpleague/commonmark#advanced-usage--customization) aspects can be provided using a separate sculpin bundle.
